### PR TITLE
refactor: Page Object セレクタを codegen ベースに置き換え (Phase 2)

### DIFF
--- a/playwright/tests/page-objects/base-page.ts
+++ b/playwright/tests/page-objects/base-page.ts
@@ -6,9 +6,6 @@ import { downloadImages, cleanupTempFiles } from "../shared/utils";
 
 /**
  * Page Object for BASE product creation form.
- *
- * TODO: Replace selectors with codegen-generated ones.
- * Run: npx playwright codegen https://admin.thebase.com/shop_admin/items/add
  */
 export class BasePage {
   readonly page: Page;
@@ -47,21 +44,22 @@ export class BasePage {
       .first();
 
     // Form fields
-    this.titleInput = page.locator("#itemDetail_name");
-    this.descriptionInput = page.locator("#itemDetail_detail");
-    this.priceInput = page.locator("#itemDetail_price");
-    this.stockInput = page.locator("#itemDetail_stock");
+    this.titleInput = page.getByRole('textbox', { name: '商品名' });
+    this.descriptionInput = page.getByRole('textbox', { name: '商品説明' });
+    this.priceInput = page.getByRole('textbox', { name: /価格/ });
+    this.stockInput = page.getByRole('textbox', { name: /在庫/ });
     this.imageFileInput = page.locator(
       "input.m-uploadBox__input[type='file']"
     );
 
     // Publish toggle
-    this.publishInput = page.locator(
-      'xpath=//p[contains(normalize-space(),"公開する")]/ancestor::*[self::label or contains(@class,"c-checkbox")][1]//input[@type="checkbox"] | //input[@type="checkbox"][contains(@name,"publish")] | //input[@type="checkbox"][contains(@id,"publish")]'
-    );
-    this.publishToggleArea = page.locator(
-      'xpath=//p[contains(normalize-space(),"公開する")]/ancestor::*[self::label or contains(@class,"c-checkbox")]'
-    );
+    this.publishInput = page
+      .locator('label')
+      .filter({ hasText: '非公開' })
+      .locator('input[type="checkbox"]');
+    this.publishToggleArea = page
+      .locator('label')
+      .filter({ hasText: '非公開' });
 
     // Navigation
     this.registerButton = page
@@ -165,10 +163,7 @@ export class BasePage {
       imageFiles = [fallback];
     }
     if (imageFiles.length) {
-      await this.page.setInputFiles(
-        "input.m-uploadBox__input[type='file']",
-        imageFiles
-      );
+      await this.imageFileInput.setInputFiles(imageFiles);
     }
     return tempFiles; // Caller is responsible for cleanup
   }

--- a/playwright/tests/page-objects/creema-page.ts
+++ b/playwright/tests/page-objects/creema-page.ts
@@ -4,22 +4,16 @@ import { downloadImages, cleanupTempFiles } from "../shared/utils";
 
 /**
  * Page Object for Creema product creation form.
- *
- * Current selectors were captured from browser DevTools.
- * TODO: Replace with codegen-generated selectors for better resilience.
- * Run: npx playwright codegen https://www.creema.jp/my/item/create
  */
 export class CreemaPage {
   readonly page: Page;
 
   // --- Login selectors ---
-  // TODO: codegen で取得したセレクタに置き換え
   readonly loginEmail: Locator;
   readonly loginPassword: Locator;
   readonly loginSubmit: Locator;
 
   // --- Form selectors ---
-  // TODO: codegen で取得したセレクタに置き換え
   readonly titleInput: Locator;
   readonly descriptionInput: Locator;
   readonly priceInput: Locator;
@@ -50,9 +44,9 @@ export class CreemaPage {
     this.loginSubmit = page.locator("input.js-user-login-button");
 
     // Form fields
-    this.titleInput = page.locator("#form-item-title");
-    this.descriptionInput = page.locator("#form-item-description");
-    this.priceInput = page.locator("#form-item-price");
+    this.titleInput = page.getByRole('textbox', { name: /作品タイトル/ });
+    this.descriptionInput = page.getByRole('textbox', { name: /作品紹介文/ });
+    this.priceInput = page.getByRole('textbox', { name: /価格/ });
     this.stockSelect = page.locator("select.js-attach-stock");
     this.materialSelect = page.locator("#form-item-material-id");
     this.imageFileInput = page.locator("input.js-file-upload");
@@ -63,17 +57,17 @@ export class CreemaPage {
       "select[name='item[shipping_methods][]']"
     );
     this.craftPeriodSelect = page.locator("select[name='item[craft_period]']");
-    this.sizeTextarea = page.locator("#form-item-size-freeinput");
-    this.categoryLevel1Select = page.locator("#form-item-level1-category-id");
+    this.sizeTextarea = page.getByRole('textbox', { name: /500文字以内/ });
+    this.categoryLevel1Select = page.getByLabel('カテゴリ （必須）');
     this.categoryLevel2Select = page.locator("#form-item-level2-category-id");
     this.categoryLevel3Select = page.locator("#form-item-level3-category-id");
     this.colorCheckboxes = "input.js-item-skus-color-ids";
     this.tagHiddenInput = page.locator("#form-item-tags");
 
     // Navigation
-    this.nextStepButton = page.locator("input.js-item-next");
+    this.nextStepButton = page.getByRole('button', { name: '入力内容の確認' });
     this.confirmButton = page.locator("input.js-item-confirm");
-    this.saveDraftButton = page.locator("input.js-item-form-draft");
+    this.saveDraftButton = page.getByRole('button', { name: '保存する' });
   }
 
   async login(email: string, password: string, baseURL: string) {
@@ -166,7 +160,7 @@ export class CreemaPage {
     if (!files.length) return;
     try {
       await expect(this.imageFileInput).toBeAttached();
-      await this.page.setInputFiles("input.js-file-upload", files);
+      await this.imageFileInput.setInputFiles(files);
       await this.waitForImagePreview(files.length);
     } catch (error) {
       console.warn("[creema] image upload failed", error);
@@ -275,7 +269,7 @@ export class CreemaPage {
     await expect(this.page).toHaveURL(/\/my\/item\/input\/preview/);
 
     const saveButton = this.page
-      .locator(`input.js-item-form-draft[value="保存する"]:visible`)
+      .getByRole('button', { name: '保存する' })
       .first();
     await expect(saveButton).toBeVisible();
     await saveButton.scrollIntoViewIfNeeded();

--- a/playwright/tests/page-objects/iichi-page.ts
+++ b/playwright/tests/page-objects/iichi-page.ts
@@ -6,19 +6,12 @@ import { downloadImages, cleanupTempFiles } from "../shared/utils";
 
 /**
  * Page Object for iichi product creation form.
- *
- * TODO: Replace selectors with codegen-generated ones.
- * Run: npx playwright codegen https://www.iichi.com/your/item/create
- *
- * NOTE: Many selectors use CSS module hashes (e.g. --MsSNs, --y8Xy7)
- * which break on every rebuild. These MUST be replaced with stable selectors.
  */
 export class IichiPage {
   readonly page: Page;
   private static readonly ROOT_URL = "https://www.iichi.com";
 
   // --- Login selectors ---
-  // WARNING: CSS module hashes - will break on rebuild!
   readonly loginLink: Locator;
   readonly loginEmail: Locator;
   readonly loginPassword: Locator;
@@ -33,20 +26,18 @@ export class IichiPage {
   readonly imageFileInput: Locator;
   readonly saveButton: Locator;
 
-  // WARNING: CSS module hash - will break on rebuild!
   readonly successPopupTitle: Locator;
 
   constructor(page: Page) {
     this.page = page;
 
     // Login
-    this.loginLink = page
-      .locator("a.HeaderIcons__text--MsSNs[href='/signin']")
-      .first();
+    this.loginLink = page.locator("a[href='/signin']").first();
     this.loginEmail = page.locator("input[name='email']");
     this.loginPassword = page.locator("input[name='password']");
     this.loginContainer = page
-      .locator(".SigninSignupForm__container--y8Xy7")
+      .locator("form")
+      .filter({ has: page.locator("input[name='email']") })
       .first();
     this.loginSubmitButton = page
       .locator("button[type='submit'], input[type='submit']")
@@ -63,7 +54,7 @@ export class IichiPage {
     this.saveButton = page.getByRole("button", { name: /保存/ }).first();
 
     // Success indicator
-    this.successPopupTitle = page.locator(".AfterPostPopup__title--jnwVU");
+    this.successPopupTitle = page.getByText(/保存されました/);
   }
 
   async navigateToLogin() {

--- a/playwright/tests/page-objects/minne-page.ts
+++ b/playwright/tests/page-objects/minne-page.ts
@@ -6,9 +6,6 @@ import { downloadImages, cleanupTempFiles } from "../shared/utils";
 
 /**
  * Page Object for minne product creation form.
- *
- * TODO: Replace selectors with codegen-generated ones.
- * Run: npx playwright codegen https://minne.com/account/products/new
  */
 export class MinnePage {
   readonly page: Page;
@@ -41,15 +38,13 @@ export class MinnePage {
     this.loginSubmit = page.locator("input.c-magic-link-sending-button");
 
     // Form fields
-    this.titleInput = page.locator("#name");
-    this.categoryParentSelect = page.locator("#category");
-    this.categoryChildSelect = page
-      .locator("select[aria-label*='小カテゴリー']")
-      .first();
-    this.descriptionTextarea = page.locator("#description");
-    this.priceInput = page.locator("#price");
-    this.stockInput = page.locator("#stock-unit");
-    this.shippingDaysInput = page.locator("#shipping-days");
+    this.titleInput = page.getByRole('textbox', { name: /作品名/ });
+    this.categoryParentSelect = page.getByLabel('大カテゴリー');
+    this.categoryChildSelect = page.getByLabel('小カテゴリー');
+    this.descriptionTextarea = page.getByRole('textbox', { name: /作品説明/ });
+    this.priceInput = page.getByRole('spinbutton', { name: /販売価格/ });
+    this.stockInput = page.getByRole('spinbutton', { name: /在庫と単位/ });
+    this.shippingDaysInput = page.getByRole('spinbutton', { name: /発送までの目安/ });
     this.imageFileInput = page.locator("input[type='file']").first();
     this.shippingMethodSelect = page.locator("#shipping-method-shipped-by-0");
     this.shippingAreaInput = page.locator("#shipping-method-shipped-to-0");
@@ -58,11 +53,8 @@ export class MinnePage {
       "#shipping-method-additional-cost-0"
     );
     this.submitButton = page
-      .locator("button.gtm-products-new-submit-click-tracking-web-front")
-      .first();
-    this.flashSuccess = page.locator(
-      "p.AccountPhysicalProductPage_flash-message-success__CI_ug"
-    );
+      .getByRole('button', { name: 'この内容で登録・更新する' });
+    this.flashSuccess = page.locator('[class*="flash-message-success"]');
   }
 
   async sendLoginLink(email: string) {


### PR DESCRIPTION
## Summary

- **iichi-page.ts**: CSS モジュールハッシュ 3箇所を削除（`loginLink`, `loginContainer`, `successPopupTitle`）
- **base-page.ts**: `#itemDetail_*` ID → `getByRole('textbox')`、40行超の XPath → `label` filter、`setInputFiles` をプロパティ経由に統一
- **minne-page.ts**: `#id` セレクタ 7箇所 → `getByRole`/`getByLabel`/`spinbutton`、GTM クラス → `getByRole`、CSS モジュールハッシュ → 部分一致
- **creema-page.ts**: `#form-item-*` ID 5箇所 → `getByRole`/`getByLabel`、JS クラス 3箇所 → `getByRole`、`setInputFiles` をプロパティ経由に統一

メソッドのシグネチャやロジックは変更なし。セレクタ定義の更新のみ。

## Test plan

- [ ] `npx tsc --noEmit` で型エラーなし（確認済み）
- [ ] `npx playwright test iichi-draft.spec.ts --headed` で iichi セレクタ動作確認
- [ ] `npx playwright test base-draft.spec.ts --headed` で BASE セレクタ動作確認
- [ ] `npx playwright test minne-draft.spec.ts --headed` で minne セレクタ動作確認
- [ ] `npx playwright test creema-draft.spec.ts --headed` で creema セレクタ動作確認
- [ ] minne の `spinbutton` で `fill()` が正常動作するか確認
- [ ] iichi の form ベース `loginContainer` で `waitFor` が動作するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)