### PR TITLE
Phase 3+4: Spec リファクタリング・不足フィールド追加

### DIFF
--- a/playwright/tests/creema-draft.spec.ts
+++ b/playwright/tests/creema-draft.spec.ts
@@ -15,9 +15,6 @@ console.log(
   "[creema-draft] PLAYWRIGHT_RUN_CREEMA=",
   JSON.stringify(process.env.PLAYWRIGHT_RUN_CREEMA)
 );
-const CREEMA_LOGIN_PATH = "/user/login";
-const CREEMA_AFTER_LOGIN_PATH = "/my/home";
-const CREEMA_NEW_ITEM_PATH = "/my/item/create";
 
 const CREEMA_MATERIAL_OPTIONS = [
   { id: "2", label: "シルバー", aliases: ["銀", "silver", "sv"] },
@@ -140,27 +137,8 @@ test.describe("Creema 自動化フロー", () => {
     const creemaPage = new CreemaPage(page);
     const origin = baseURL ?? "https://www.creema.jp";
 
-    testInfo.annotations.push({
-      type: "TODO",
-      description:
-        "selectors オブジェクトを実際の Creema 画面に合わせて調整してください。",
-    });
-
-    await test.step("ログインページへ遷移", async () => {
-      await page.goto(`${origin}${CREEMA_LOGIN_PATH}`);
-      await expect(page).toHaveURL(/\/user\/login/);
-    });
-
-    await test.step("認証情報を入力", async () => {
-      await creemaPage.loginEmail.fill(email!);
-      await creemaPage.loginPassword.fill(password!);
-      await Promise.all([
-        page.waitForURL(
-          `${origin}${CREEMA_AFTER_LOGIN_PATH}`,
-          { timeout: 120_000 }
-        ),
-        creemaPage.loginSubmit.click(),
-      ]);
+    await test.step("ログイン", async () => {
+      await creemaPage.login(email!, password!, origin);
     });
 
     await test.step("商品登録画面を開く", async () => {
@@ -214,15 +192,8 @@ test.describe("Creema 自動化フロー", () => {
         await creemaPage.goToShippingStep();
 
         if (mapped.shippingOriginPrefectureId) {
-          const success = await creemaPage.setSelectValue(
-            "select[name='item[delivery_from_prefecture_id]']",
-            mapped.shippingOriginPrefectureId
-          );
-          if (!success) {
-            console.warn(
-              "[creema-draft] shipping origin option not selectable",
-              mapped.shippingOriginPrefectureId
-            );
+          if (!(await creemaPage.fillShippingOrigin(mapped.shippingOriginPrefectureId))) {
+            console.warn("[creema-draft] shipping origin not selectable", mapped.shippingOriginPrefectureId);
           }
         } else if (
           pickFirstNonEmpty(
@@ -236,15 +207,8 @@ test.describe("Creema 自動化フロー", () => {
         }
 
         if (mapped.shippingMethodId) {
-          const success = await creemaPage.setSelectValue(
-            "select[name='item[shipping_methods][]']",
-            mapped.shippingMethodId
-          );
-          if (!success) {
-            console.warn(
-              "[creema-draft] shipping method not selectable",
-              mapped.shippingMethodId
-            );
+          if (!(await creemaPage.fillShippingMethod(mapped.shippingMethodId))) {
+            console.warn("[creema-draft] shipping method not selectable", mapped.shippingMethodId);
           }
         } else if (
           pickFirstNonEmpty(
@@ -257,15 +221,8 @@ test.describe("Creema 自動化フロー", () => {
         }
 
         if (mapped.craftPeriodId) {
-          const success = await creemaPage.setSelectValue(
-            "select[name='item[craft_period]']",
-            mapped.craftPeriodId
-          );
-          if (!success) {
-            console.warn(
-              "[creema-draft] craft period not selectable",
-              mapped.craftPeriodId
-            );
+          if (!(await creemaPage.fillCraftPeriod(mapped.craftPeriodId))) {
+            console.warn("[creema-draft] craft period not selectable", mapped.craftPeriodId);
           }
         } else if (
           pickFirstNonEmpty(
@@ -278,11 +235,7 @@ test.describe("Creema 自動化フロー", () => {
         }
 
         if (mapped.sizeFreeInput) {
-          const success = await creemaPage.setTextareaValue(
-            "#form-item-size-freeinput",
-            mapped.sizeFreeInput
-          );
-          if (!success) {
+          if (!(await creemaPage.fillSizeFreeInput(mapped.sizeFreeInput))) {
             console.warn("[creema-draft] size textarea not fillable", mapped.sizeFreeInput);
           }
         }

--- a/playwright/tests/iichi-draft.spec.ts
+++ b/playwright/tests/iichi-draft.spec.ts
@@ -5,7 +5,7 @@ import { IichiPage } from "./page-objects/iichi-page";
 import { pickFirstNonEmpty, parseInteger, parseImageUrls, cleanupTempFiles } from "./shared/utils";
 
 const RUN_IICHI_FLOW = process.env.PLAYWRIGHT_RUN_IICHI === "true";
-const ENABLE_IICHI_CATEGORY_SELECTION = false;
+const ENABLE_IICHI_CATEGORY_SELECTION = true;
 
 test.describe("iichi 自動化フロー", () => {
   test.skip(!RUN_IICHI_FLOW, "PLAYWRIGHT_RUN_IICHI=true を指定したときのみ実行します。");

--- a/playwright/tests/page-objects/base-page.ts
+++ b/playwright/tests/page-objects/base-page.ts
@@ -168,6 +168,44 @@ export class BasePage {
     return tempFiles; // Caller is responsible for cleanup
   }
 
+  async selectCategory(categoryLabel: string | null): Promise<boolean> {
+    if (!categoryLabel) return false;
+    const categorySelect = this.page
+      .locator("select")
+      .filter({ has: this.page.locator(`option:has-text("${categoryLabel}")`) })
+      .first();
+    if ((await categorySelect.count()) === 0) {
+      console.warn("[base] category select not found for", categoryLabel);
+      return false;
+    }
+    try {
+      await categorySelect.selectOption({ label: categoryLabel });
+      return true;
+    } catch {
+      console.warn("[base] category option not selectable", categoryLabel);
+      return false;
+    }
+  }
+
+  async fillShippingMethod(method: string | null): Promise<boolean> {
+    if (!method) return false;
+    const shippingSelect = this.page
+      .locator("select")
+      .filter({ has: this.page.locator("option:has-text('宅配便')") })
+      .first();
+    if ((await shippingSelect.count()) === 0) {
+      console.warn("[base] shipping method select not found");
+      return false;
+    }
+    try {
+      await shippingSelect.selectOption({ label: method });
+      return true;
+    } catch {
+      console.warn("[base] shipping method not selectable", method);
+      return false;
+    }
+  }
+
   async submitForm() {
     await Promise.all([
       this.page.waitForLoadState("networkidle"),

--- a/playwright/tests/page-objects/creema-page.ts
+++ b/playwright/tests/page-objects/creema-page.ts
@@ -260,6 +260,35 @@ export class CreemaPage {
     );
   }
 
+  async fillShippingOrigin(prefectureId: string | null): Promise<boolean> {
+    if (!prefectureId) return false;
+    return this.setSelectValue(
+      "select[name='item[delivery_from_prefecture_id]']",
+      prefectureId
+    );
+  }
+
+  async fillShippingMethod(methodId: string | null): Promise<boolean> {
+    if (!methodId) return false;
+    return this.setSelectValue(
+      "select[name='item[shipping_methods][]']",
+      methodId
+    );
+  }
+
+  async fillCraftPeriod(periodId: string | null): Promise<boolean> {
+    if (!periodId) return false;
+    return this.setSelectValue(
+      "select[name='item[craft_period]']",
+      periodId
+    );
+  }
+
+  async fillSizeFreeInput(text: string | null): Promise<boolean> {
+    if (!text) return false;
+    return this.setTextareaValue("#form-item-size-freeinput", text);
+  }
+
   async confirmAndSaveDraft() {
     await expect(this.confirmButton).toBeVisible();
     await Promise.all([


### PR DESCRIPTION
## Summary
- **CreemaPage**: 配送元・配送方法・制作期間・サイズのメソッドを追加。spec から生CSSセレクタを完全除去
- **creema-draft.spec.ts**: `login()` メソッドに書き換え、手動ログインフロー・不要な定数(`CREEMA_LOGIN_PATH` 等)を削除
- **BasePage**: `selectCategory()` / `fillShippingMethod()` メソッド追加（Phase 4: 不足フィールド）
- **iichi-draft.spec.ts**: `ENABLE_IICHI_CATEGORY_SELECTION = true` に変更（Phase 4: カテゴリ選択有効化）

## Phase 対応
- Phase 3（Spec リファクタリング）: creema spec から生セレクタを排除し Page Object メソッドに統一
- Phase 4（不足フィールド追加）: BASE カテゴリ/配送、iichi カテゴリ有効化

## Test plan
- [ ] `pnpm lint` が通ること ✅
- [ ] `npx tsc --noEmit` が通ること ✅
- [ ] headed モードで各プラットフォームのテストが動作すること

https://claude.ai/code/session_01LHVkcxTnma23eDkjzdcbSd